### PR TITLE
Propagate cancellation when a TransportException occurs

### DIFF
--- a/reactivesocket-netty/src/main/java/io/reactivesocket/netty/tcp/client/ClientTcpDuplexConnection.java
+++ b/reactivesocket-netty/src/main/java/io/reactivesocket/netty/tcp/client/ClientTcpDuplexConnection.java
@@ -98,8 +98,11 @@ public class ClientTcpDuplexConnection implements DuplexConnection {
     @Override
     public void addOutput(Publisher<Frame> o, Completable callback) {
         o.subscribe(new Subscriber<Frame>() {
+            private Subscription subscription;
+
             @Override
             public void onSubscribe(Subscription s) {
+                subscription = s;
                 s.request(Long.MAX_VALUE);
             }
 
@@ -126,6 +129,9 @@ public class ClientTcpDuplexConnection implements DuplexConnection {
             @Override
             public void onError(Throwable t) {
                 callback.error(t);
+                if (t instanceof TransportException) {
+                    subscription.cancel();
+                }
             }
 
             @Override

--- a/reactivesocket-netty/src/main/java/io/reactivesocket/netty/websocket/client/ClientWebSocketDuplexConnection.java
+++ b/reactivesocket-netty/src/main/java/io/reactivesocket/netty/websocket/client/ClientWebSocketDuplexConnection.java
@@ -119,8 +119,11 @@ public class ClientWebSocketDuplexConnection implements DuplexConnection {
     @Override
     public void addOutput(Publisher<Frame> o, Completable callback) {
         o.subscribe(new Subscriber<Frame>() {
+            private Subscription subscription;
+
             @Override
             public void onSubscribe(Subscription s) {
+                subscription = s;
                 s.request(Long.MAX_VALUE);
             }
 
@@ -148,6 +151,9 @@ public class ClientWebSocketDuplexConnection implements DuplexConnection {
             @Override
             public void onError(Throwable t) {
                 callback.error(t);
+                if (t instanceof TransportException) {
+                    subscription.cancel();
+                }
             }
 
             @Override


### PR DESCRIPTION
**Problem**
When a TransportException happens on the transport, it is propagated up
in the chain but the Susbscription is not cancelled. Then, any source
associated with the chain continue to emit events.

One example of that is the Keep-Alive Observable, which regularly emit
keep-alive messages at fixed interval, when the connection is closed, the
observable has to be cancelled.

**Solution**
In all DuplexConnection implementation, cancel the Subscription when we
saw a TransportException.